### PR TITLE
Add options for disabling some of the transforms, especially named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ require('babel').transform('code', {
 });
 ```
 
+### Options
+
+The various transforms done by this module can be disabled individually.  This is especially useful if you need this module to convert `import` statements into reasonable commonjs statements, but require the default Babel behavior for exported functions (which get hoisted to the beginning of the scope, thus always exporting correctly even if circular dependencies exist - for this set the `exportNamed` option to `false`).
+
+**.babelrc example: disable everything**
+
+```json
+{
+  "plugins": [
+    ["transform-modules-simple-commonjs", {
+      "exportNamed": false,
+      "exportDefault": false,
+      "exportAll": false,
+      "import": false
+    }]
+  ]
+}
+```
+
 ### Usage with other plugins
 
-This replaces the functionality in `@babel/plugin-transform-modules-commonjs`, which needs to be disabled when using this plugin.
+By default, this replaces the functionality in `@babel/plugin-transform-modules-commonjs`, which needs to be disabled or after this plugin.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",
+    "@babel/plugin-transform-modules-commonjs": "^7.15.4",
     "chalk": "^4.1.1",
     "clear": "0.1.0",
     "diff": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ module.exports = function ({ types: t }) {
     inherits: require('@babel/plugin-transform-strict-mode').default,
     visitor: {
       Program: {
-        exit(path) {
+        exit(path, state) {
           const sources = []
           const anonymousSources = []
           const { scope } = path
@@ -58,7 +58,7 @@ module.exports = function ({ types: t }) {
           }
 
           for (const path of body) {
-            if (path.isExportDefaultDeclaration()) {
+            if (path.isExportDefaultDeclaration() && state.opts.exportDefault !== false) {
               hasDefaultExport = true
               lastExportPath = path
               const declaration = path.get('declaration')
@@ -74,7 +74,7 @@ module.exports = function ({ types: t }) {
               continue
             }
 
-            if (path.isImportDeclaration()) {
+            if (path.isImportDeclaration() && state.opts.import !== false) {
               const specifiers = path.node.specifiers
               const is2015Compatible = path.node.source.value.match(/@babel\/runtime[\\/]/)
               if (specifiers.length === 0) {
@@ -116,7 +116,7 @@ module.exports = function ({ types: t }) {
               continue
             }
 
-            if (path.isExportNamedDeclaration()) {
+            if (path.isExportNamedDeclaration() && state.opts.exportNamed !== false) {
               lastExportPath = path
               const declaration = path.get('declaration')
 
@@ -189,7 +189,7 @@ module.exports = function ({ types: t }) {
               continue
             }
 
-            if (path.isExportAllDeclaration()) {
+            if (path.isExportAllDeclaration() && state.opts.exportAll !== false) {
               // export * from 'a';
               const importedID = addSource(path)
               const keyName = path.scope.generateUidIdentifier(importedID.name + '_key')

--- a/test/fixtures/disable-export-named/actual.js
+++ b/test/fixtures/disable-export-named/actual.js
@@ -1,0 +1,5 @@
+import assert from 'assert';
+
+export function d() {
+	assert(false);
+}

--- a/test/fixtures/disable-export-named/expected.js
+++ b/test/fixtures/disable-export-named/expected.js
@@ -1,0 +1,10 @@
+"use strict";
+
+exports.__esModule = true;
+exports.d = d;
+
+var assert = require('assert');
+
+function d() {
+  assert(false);
+}

--- a/test/fixtures/disable-export-named/opts.json
+++ b/test/fixtures/disable-export-named/opts.json
@@ -1,0 +1,8 @@
+{
+  "opts": {
+    "exportNamed": false
+  },
+  "plugins": [
+    ["@babel/plugin-transform-modules-commonjs", { "loose": true }]
+  ]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -23,10 +23,20 @@ function runTests() {
     .forEach(runTest)
 }
 
+function loadOpts(dir) {
+  const optsPath = path.resolve(dir.path, 'opts.json')
+  if (fs.existsSync(optsPath)) {
+    return JSON.parse(fs.readFileSync(optsPath, 'utf8'))
+  } else {
+    return { opts: {}, plugins: [] };
+  }
+}
+
 function runTest(dir) {
+  const opts = loadOpts(dir);
   const output = babel.transformFileSync(path.resolve(dir.path, 'actual.js'), {
     babelrc: false,
-    plugins: [pluginPath],
+    plugins: [[pluginPath, opts.opts]].concat(opts.plugins),
   })
 
   const expected = fs.readFileSync(path.resolve(dir.path, 'expected.js'), 'utf-8')


### PR DESCRIPTION
This module very nicely fixes `import` statements to generate reasonable `require()` statements, however it's mangling exported functions (causing them to be exported *after* all of the require() statements are executed, instead of *before*, which causes any circular dependencies to yield a set of imports getting `undefined` instead of the function).

This PR adds some trivial configurable options to disable the different parts of this transform (though, I'm not sure if anything other than `exportNamed` would ever be useful), and a test for the important option (still get nice-looking `require` statements from the `import` and well-ordered `exports` assignments).